### PR TITLE
Deprecate xlrd

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ deprecate_xlrd ]
   pull_request:
-    branches: [ master ]
+    branches: [ deprecate_xlrd ]
   workflow_dispatch:
   
 

--- a/mdciao/nomenclature/nomenclature.py
+++ b/mdciao/nomenclature/nomenclature.py
@@ -67,7 +67,7 @@ def table2BW_by_AAcode(tablefile,
     """
 
     if isinstance(tablefile,str):
-        df = _read_excel(tablefile, header=0)
+        df = _read_excel(tablefile, header=0, engine="openpyxl")
     else:
         df = tablefile
 
@@ -356,8 +356,9 @@ def BW_finder(BW_descriptor,
     url = "%s/%s" % (GPCRmd, BW_descriptor)
 
     local_lookup_lambda = lambda fullpath : _read_excel(fullpath,
+                                                        engine="openpyxl",
                                                         usecols=lambda x : x.lower()!="unnamed: 0",
-                                                        converters={"BW": str}).replace({_np.nan: None})
+                                                        converters={"BW": str}).replace({_np.nan: None},)
     web_looukup_lambda = lambda url : _BW_web_lookup(url, verbose=verbose)
     print("Using BW-nomenclature, please cite the following 3rd party publications:\n"
           " * https://doi.org/10.1016/S1043-9471(05)80049-7 (Weinstein et al 1995)\n"

--- a/mdciao/utils/str_and_dict.py
+++ b/mdciao/utils/str_and_dict.py
@@ -361,7 +361,7 @@ def freq_file2dict(ifile, defrag=None):
     """
     ext = _path.splitext(ifile)[-1]
     if ext.lower() == ".xlsx":
-        df = _read_excel(ifile)
+        df = _read_excel(ifile, engine="openpyxl")
         if "freq" in df.keys() and "label" in df.keys():
             res = {key: val for key, val in zip(df["label"].values, df["freq"].values)}
         else:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
                     "msmtools",
                     "scipy",
                     "joblib",
-                    "xlrd",
+                    "openpyxl",
                     "biopython",
                     "ipython",
                     "XlsxWriter",

--- a/tests/test_nomenclature.py
+++ b/tests/test_nomenclature.py
@@ -256,7 +256,7 @@ class Test_table2BW_by_AAcode(unittest.TestCase):
                                    "TM2" : ["T66","V67"]})
     def test_table2B_by_AAcode_already_DF(self):
         from pandas import read_excel
-        df = read_excel(self.file, header=0)
+        df = read_excel(self.file, header=0, engine="openpyxl")
 
         table2BW = nomenclature.table2BW_by_AAcode(tablefile=df)
         self.assertDictEqual(table2BW,


### PR DESCRIPTION
xlrd as an Excel engine no longer reads the xlsx format, see https://xlrd.readthedocs.io/en/latest/

Switching to recommended openpyxl, see http://www.python-excel.org/, using engine=openpxl whenever calling read_excel

Originally found via :

https://stackoverflow.com/questions/65254535/xlrd-biffh-xlrderror-excel-xlsx-file-not-supported