### PR TITLE
Latex

### DIFF
--- a/mdciao/cli/cli.py
+++ b/mdciao/cli/cli.py
@@ -1066,7 +1066,7 @@ def residue_neighborhoods(residues,
             title = ihood.anchor_res_and_fragment_str
             if short_AA_names:
                 title = ihood.anchor_res_and_fragment_str_short
-            title = _mdcu.str_and_dict.replace4latex(title.replace("@","^"))
+            title = _mdcu.str_and_dict.latex_superscript_fragments(title)
             if n_nearest >0:
                 title += "\n%u nearest bonded neighbors excluded" % (n_nearest)
             _manage_timedep_ploting_and_saving_options(ihood, myfig,

--- a/mdciao/contacts/contacts.py
+++ b/mdciao/contacts/contacts.py
@@ -3274,7 +3274,7 @@ class ContactGroup(object):
                                                label_bars[:(jax.get_xlim()[1]).astype(int) + 1],
                                                label_fontsize_factor=label_fontsize_factor,
                                                trunc_y_labels_at=.65 * _np.max(freqs),
-                                               allow_splitting=False,
+                                               single_label=True,
                                                )
 
         if xmax is not None:

--- a/mdciao/contacts/contacts.py
+++ b/mdciao/contacts/contacts.py
@@ -1622,10 +1622,7 @@ class ContactPair(object):
         ctc_label = self.labels.w_fragments
         if shorten_AAs:
             ctc_label = self.labels.w_fragments_short_AA
-
-        ctc_label = '-'.join(_mdcu.str_and_dict.replace4latex(word.replace("@", "^")) for word in
-                       _mdcu.str_and_dict.splitlabel(ctc_label, "-"))
-
+        ctc_label = _mdcu.str_and_dict.latex_superscript_fragments(ctc_label)
         if ctc_cutoff_Ang > 0:
             ctc_label += " (%u%%)" % (self.frequency_overall_trajs(ctc_cutoff_Ang, switch_off_Ang=switch_off_Ang) * 100)
 
@@ -2733,7 +2730,7 @@ class ContactGroup(object):
                 label_dotref += '\nSigma = %2.1f' % sigma  # sum over all bc we did not truncate
                 jax.plot(_np.nan, _np.nan, 'o',
                          color=self.anchor_fragment_color,
-                         label=_mdcu.str_and_dict.replace4latex(label_dotref.replace("@","^")))
+                         label=_mdcu.str_and_dict.latex_superscript_fragments(label_dotref))
         else:
             if sum_freqs:
                 title+= " of '%s' (Sigma = %2.1f)\n" % (title_label,sigma)
@@ -3009,7 +3006,7 @@ class ContactGroup(object):
             label_dotref = _mdcu.str_and_dict.defrag_key(label_dotref,defrag=defrag)
             label_bars = [_mdcu.str_and_dict.defrag_key(ilab,defrag=defrag) for ilab in label_bars]
         # Cosmetics
-        title_str = "distribution for %s"%_mdcu.str_and_dict.replace4latex(label_dotref.replace("@","^"))
+        title_str = "distribution for %s"%_mdcu.str_and_dict.latex_superscript_fragments(label_dotref)
         if ctc_cutoff_Ang is not None:
             title_str += "\nresidues within %2.1f $\AA$"%(ctc_cutoff_Ang)
             jax.axvline(ctc_cutoff_Ang,color="k",ls="--",zorder=-1)
@@ -3019,11 +3016,12 @@ class ContactGroup(object):
 
         # Base plot
         for ii, ((h, x), label) in enumerate(zip(self.distributions_of_distances(nbins=nbins), label_bars)):
+            label = _mdcu.str_and_dict.latex_superscript_fragments(label)
             if ctc_cutoff_Ang is not None:
                 if ii==0:
                     freqs = self.frequency_per_contact(ctc_cutoff_Ang)
                 label+=" (%u%%)"%(freqs[ii]*100)
-            jax.plot(x[:-1] * 10, h, label=_mdcu.str_and_dict.replace4latex(label.replace("@","^")))
+            jax.plot(x[:-1] * 10, h, label=label)
             jax.fill_between(x[:-1]*10, h, alpha=.15)
         if xlim is not None:
             jax.set_xlim(xlim)

--- a/mdciao/plots/plots.py
+++ b/mdciao/plots/plots.py
@@ -558,7 +558,7 @@ def plot_unified_freq_dicts(freqs,
 def add_tilted_labels_to_patches(jax, labels,
                                  label_fontsize_factor=1,
                                  trunc_y_labels_at=.65,
-                                 allow_splitting=True):
+                                 single_label=False):
     r"""
     Iterate through :obj:`jax.patches` and place the text strings
     in :obj:`labels` on top of it.

--- a/mdciao/plots/plots.py
+++ b/mdciao/plots/plots.py
@@ -235,7 +235,8 @@ def compare_groups_of_contacts(groups,
                                     fontsize=fontsize,
                                     **kwargs_plot_unified_freq_dicts)
             if anchor is not None:
-                _plt.gca().text(0 - _np.abs(_np.diff(_plt.gca().get_xlim()))*.05, 1.05, "%s and:" % _mdcu.str_and_dict.replace4latex(anchor.replace("@","^")),
+                _plt.gca().text(0 - _np.abs(_np.diff(_plt.gca().get_xlim())) * .05, 1.05,
+                                "%s and:" % _mdcu.str_and_dict.latex_superscript_fragments(anchor),
                                 ha="right", va="bottom")
 
         myfig.tight_layout()
@@ -257,8 +258,9 @@ def compare_groups_of_contacts(groups,
                                                         title=title,
                                                         **kwargs_plot_unified_freq_dicts)
     if anchor is not None:
-        _plt.text(0 - _np.abs(_np.diff(_plt.gca().get_xlim()))*.05, 1.05, "%s and:" % _mdcu.str_and_dict.replace4latex(anchor.replace("@","^")),
-                                                                                                                       ha="right", va="bottom", fontsize=fontsize)
+        _plt.text(0 - _np.abs(_np.diff(_plt.gca().get_xlim())) * .05, 1.05,
+                  "%s and:" % _mdcu.str_and_dict.latex_superscript_fragments(anchor),
+                  ha="right", va="bottom", fontsize=fontsize)
     _plt.gcf().tight_layout()
     #_plt.show()
 
@@ -515,11 +517,7 @@ def plot_unified_freq_dicts(freqs,
             iix = ii\
                   -width/2\
                   +len(freqs_by_sys_by_ctc)*width/2
-            txt = key.replace("@", "^")
-            if "-" in txt:
-                txt = "-".join([_mdcu.str_and_dict.replace4latex(w) for w in _mdcu.str_and_dict.splitlabel(txt,"-")])
-            else:
-                txt = _mdcu.str_and_dict.replace4latex(txt)
+            txt = _mdcu.str_and_dict.latex_superscript_fragments(key)
             txt = winners[key][0] + txt
             _plt.text(iix, ylim + .05, txt,
                       #ha="center",
@@ -582,10 +580,10 @@ def add_tilted_labels_to_patches(jax, labels,
         iy += .01
         if iy > trunc_y_labels_at:
             iy = trunc_y_labels_at
-        if "-" in ilab and allow_splitting:
-            txt = '-'.join(_mdcu.str_and_dict.replace4latex(word.replace("@","^")) for word in _mdcu.str_and_dict.splitlabel(ilab,"-"))
+        if single_label:
+            txt = _mdcu.str_and_dict._latex_superscript_one_fragment(ilab)
         else:
-            txt = _mdcu.str_and_dict.replace4latex(ilab.replace("@","^"))
+            txt = _mdcu.str_and_dict.latex_superscript_fragments(ilab)
         jax.text(ix, iy, txt,
                  va='bottom',
                  ha='left',

--- a/tests/test_str_and_dict_utils.py
+++ b/tests/test_str_and_dict_utils.py
@@ -715,5 +715,18 @@ class Test_replace_regex_special_chars():
         word ="[]()^"
         assert str_and_dict._replace_regex_special_chars(word,"!!!!!")
 
+class Test_latex_mathmode(unittest.TestCase):
+
+    def test_works(self):
+        self.assertEqual("$\\mathrm{There's an }\\alpha\\mathrm{ and a }\\beta\\mathrm{ here, also C_200}$",
+                         str_and_dict.latex_mathmode("There's an alpha and a beta here, also C_200"))
+
+class Test_latex_superscript_one_fragment(unittest.TestCase):
+
+    def test_works(self):
+        self.assertEqual(str_and_dict._latex_superscript_one_fragment("GLU30@beta_2AR"),
+                         "GLU30$^{\\beta\\mathrm{_2AR}}$")
+    def test_no_fragment(self):
+        self.assertEqual(str_and_dict._latex_superscript_one_fragment("GLU30"),"GLU30")
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Trying to get around the horrible "replace4latex" and "latexify" methods, step by step, by learning more regexp and choosing to refactor the parts that can move away from replace4latex. Went from 20 to 10 usages approx.

The automatic "to-LaTeX" conversion gets easier if we identify cases where the fragment name is intended to be a superscript later or not.