### PR TITLE
Force n excluded

### DIFF
--- a/mdciao/cli/cli.py
+++ b/mdciao/cli/cli.py
@@ -987,11 +987,9 @@ def residue_neighborhoods(residues,
                                                       label_fontsize_factor=panelsize2font/panelsize,
                                                       shorten_AAs=short_AA_names,
                                                       ctc_cutoff_Ang=ctc_cutoff_Ang,
-                                                      n_nearest= n_nearest
                                                       )
                 else:
                     ihood.plot_neighborhood_freqs(ctc_cutoff_Ang,
-                                                  n_nearest,
                                                   switch_off_Ang=switch_off_Ang,
                                                   jax=jax,
                                                   xmax=_np.max([ihood.n_ctcs for ihood in neighborhoods.values() if ihood is not None]),

--- a/mdciao/cli/cli.py
+++ b/mdciao/cli/cli.py
@@ -967,46 +967,10 @@ def residue_neighborhoods(residues,
 
     if figures:
         panelheight = 3
-        n_cols = _np.min((n_cols, len(res_idxs_list)))
-        n_rows = _np.ceil(len(res_idxs_list) / n_cols).astype(int)
-        panelsize = 4
-        panelsize2font = 3.5
-        bar_fig, bar_ax = _plt.subplots(n_rows, n_cols,
-                                        sharex=True,
-                                        sharey=True,
-                                        figsize=(n_cols * panelsize * 2, n_rows * panelsize), squeeze=False)
-
-        # One loop for the histograms
-        _rcParams["font.size"]=panelsize*panelsize2font
-        for jax, ihood in zip(bar_ax.flatten(),
-                                       neighborhoods.values()):
-            if ihood is not None:
-                if distro:
-                    ihood.plot_distance_distributions(nbins=20,
-                                                      jax=jax,
-                                                      label_fontsize_factor=panelsize2font/panelsize,
-                                                      shorten_AAs=short_AA_names,
-                                                      ctc_cutoff_Ang=ctc_cutoff_Ang,
-                                                      )
-                else:
-                    ihood.plot_neighborhood_freqs(ctc_cutoff_Ang,
-                                                  switch_off_Ang=switch_off_Ang,
-                                                  jax=jax,
-                                                  xmax=_np.max([ihood.n_ctcs for ihood in neighborhoods.values() if ihood is not None]),
-                                                  label_fontsize_factor=panelsize2font / panelsize,
-                                                  shorten_AAs=short_AA_names,
-                                                  color=ihood.partner_fragment_colors,
-                                                  plot_atomtypes=plot_atomtypes
-                                                  )
-
-        if not distro:
-            non_nan_rightermost_patches = [[p for p in jax.patches if not _np.isnan(p.get_x())][-1] for jax in bar_ax.flatten() if len(jax.patches)>0]
-            xmax = _np.nanmax([p.get_x()+p.get_width()/2 for p in non_nan_rightermost_patches])+.5
-            [iax.set_xlim([-.5, xmax]) for iax in bar_ax.flatten()]
-        bar_fig.tight_layout(h_pad=2, w_pad=0, pad=0)
-        fname = "%s.overall@%2.1f_Ang.%s" % (output_desc, ctc_cutoff_Ang, graphic_ext.strip("."))
-        fname = _path.join(output_dir, fname)
+        bar_fig = _figure_overall(n_cols, res_idxs_list, neighborhoods, distro, short_AA_names, ctc_cutoff_Ang, plot_atomtypes, switch_off_Ang, output_desc, output_dir, savefiles, graphic_ext, graphic_dpi)
         if savefiles:
+            fname = "%s.overall@%2.1f_Ang.%s" % (output_desc, ctc_cutoff_Ang, graphic_ext.strip("."))
+            fname = _path.join(output_dir, fname)
             bar_fig.savefig(fname, dpi=graphic_dpi)
             print("The following files have been created")
             print(fname)
@@ -1084,6 +1048,70 @@ def residue_neighborhoods(residues,
             'ctcs_trajs': ctcs_trajs,
             'time_array': time_arrays,
             "neighborhoods": neighborhoods}
+
+def _figure_overall(n_cols, res_idxs_list, CG_list, distro, short_AA_names, ctc_cutoff_Ang, plot_atomtypes, switch_off_Ang):
+    r"""
+    Generates one figure containing the per-:obj:`~mdciao.contacts.ContactGroup` info as individual panels
+
+    Internally, prepares the subplots and iterates around plot_distance_distributions
+    or plot_neighborhood_freqs
+
+    Parameters
+    ----------
+    n_cols
+    res_idxs_list
+    CG_list
+    distro
+    short_AA_names
+    ctc_cutoff_Ang
+    plot_atomtypes
+    switch_off_Ang
+
+    Returns
+    -------
+    fig : :obj:`~matplotlib.Figure`
+
+    """
+    n_cols = _np.min((n_cols, len(res_idxs_list)))
+    n_rows = _np.ceil(len(res_idxs_list) / n_cols).astype(int)
+    panelsize = 4
+    panelsize2font = 3.5
+    bar_fig, bar_ax = _plt.subplots(n_rows, n_cols,
+                                    sharex=True,
+                                    sharey=True,
+                                    figsize=(n_cols * panelsize * 2, n_rows * panelsize), squeeze=False)
+
+    # One loop for the histograms
+    _rcParams["font.size"] = panelsize * panelsize2font
+    for jax, ihood in zip(bar_ax.flatten(),
+                          CG_list.values()):
+        if ihood is not None:
+            if distro:
+                ihood.plot_distance_distributions(nbins=20,
+                                                  jax=jax,
+                                                  label_fontsize_factor=panelsize2font / panelsize,
+                                                  shorten_AAs=short_AA_names,
+                                                  ctc_cutoff_Ang=ctc_cutoff_Ang,
+                                                  )
+            else:
+                ihood.plot_neighborhood_freqs(ctc_cutoff_Ang,
+                                              switch_off_Ang=switch_off_Ang,
+                                              jax=jax,
+                                              xmax=_np.max([ihood.n_ctcs for ihood in CG_list.values() if
+                                                            ihood is not None]),
+                                              label_fontsize_factor=panelsize2font / panelsize,
+                                              shorten_AAs=short_AA_names,
+                                              color=ihood.partner_fragment_colors,
+                                              plot_atomtypes=plot_atomtypes
+                                              )
+
+    if not distro:
+        non_nan_rightermost_patches = [[p for p in jax.patches if not _np.isnan(p.get_x())][-1] for jax in
+                                       bar_ax.flatten() if len(jax.patches) > 0]
+        xmax = _np.nanmax([p.get_x() + p.get_width() / 2 for p in non_nan_rightermost_patches]) + .5
+        [iax.set_xlim([-.5, xmax]) for iax in bar_ax.flatten()]
+    bar_fig.tight_layout(h_pad=2, w_pad=0, pad=0)
+
 
 def interface(
         trajectories,

--- a/mdciao/cli/cli.py
+++ b/mdciao/cli/cli.py
@@ -967,7 +967,12 @@ def residue_neighborhoods(residues,
 
     if figures:
         panelheight = 3
-        bar_fig = _figure_overall(n_cols, res_idxs_list, neighborhoods, distro, short_AA_names, ctc_cutoff_Ang, plot_atomtypes, switch_off_Ang, output_desc, output_dir, savefiles, graphic_ext, graphic_dpi)
+        bar_fig = _figure_overall(n_cols, neighborhoods, ctc_cutoff_Ang,
+                                  n_panels=len(res_idxs_list),
+                                  distro=distro,
+                                  short_AA_names=short_AA_names,
+                                  plot_atomtypes=plot_atomtypes,
+                                  switch_off_Ang=switch_off_Ang)
         if savefiles:
             fname = "%s.overall@%2.1f_Ang.%s" % (output_desc, ctc_cutoff_Ang, graphic_ext.strip("."))
             fname = _path.join(output_dir, fname)
@@ -1049,7 +1054,14 @@ def residue_neighborhoods(residues,
             'time_array': time_arrays,
             "neighborhoods": neighborhoods}
 
-def _figure_overall(n_cols, res_idxs_list, CG_list, distro, short_AA_names, ctc_cutoff_Ang, plot_atomtypes, switch_off_Ang):
+def _figure_overall(n_cols, CG_list, ctc_cutoff_Ang,
+                    n_panels=None,
+                    distro=False,
+                    short_AA_names=False,
+                    plot_atomtypes=False,
+                    switch_off_Ang=0,
+                    panelsize=4,
+                    panelsize2font = 3.5):
     r"""
     Generates one figure containing the per-:obj:`~mdciao.contacts.ContactGroup` info as individual panels
 
@@ -1059,11 +1071,12 @@ def _figure_overall(n_cols, res_idxs_list, CG_list, distro, short_AA_names, ctc_
     Parameters
     ----------
     n_cols
-    res_idxs_list
     CG_list
+    ctc_cutoff_Ang
+    n_panels
+
     distro
     short_AA_names
-    ctc_cutoff_Ang
     plot_atomtypes
     switch_off_Ang
 
@@ -1072,10 +1085,11 @@ def _figure_overall(n_cols, res_idxs_list, CG_list, distro, short_AA_names, ctc_
     fig : :obj:`~matplotlib.Figure`
 
     """
-    n_cols = _np.min((n_cols, len(res_idxs_list)))
-    n_rows = _np.ceil(len(res_idxs_list) / n_cols).astype(int)
-    panelsize = 4
-    panelsize2font = 3.5
+    if n_panels is None:
+        n_panels = len(CG_list)
+    n_cols = _np.min((n_cols, n_panels))
+    n_rows = _np.ceil(n_panels / n_cols).astype(int)
+
     bar_fig, bar_ax = _plt.subplots(n_rows, n_cols,
                                     sharex=True,
                                     sharey=True,
@@ -1111,6 +1125,8 @@ def _figure_overall(n_cols, res_idxs_list, CG_list, distro, short_AA_names, ctc_
         xmax = _np.nanmax([p.get_x() + p.get_width() / 2 for p in non_nan_rightermost_patches]) + .5
         [iax.set_xlim([-.5, xmax]) for iax in bar_ax.flatten()]
     bar_fig.tight_layout(h_pad=2, w_pad=0, pad=0)
+
+    return bar_fig
 
 
 def interface(
@@ -1535,8 +1551,7 @@ def interface(
 
 
         if savefiles:
-            histofig.savefig(fn.fname_histo, dpi=graphic_dpi, bbox_inches="tight")
-            print(fn.fname_histo)
+            histofig.savefig(fn.fname_overall, dpi=graphic_dpi, bbox_inches="tight")
             cmat_fig.savefig(fn.fname_mat)
             print(fn.fname_mat)
 

--- a/mdciao/cli/cli.py
+++ b/mdciao/cli/cli.py
@@ -965,6 +965,8 @@ def residue_neighborhoods(residues,
         print("The following residues have no neighbors at %2.1f Ang, their frequency histograms will be empty"%ctc_cutoff_Ang)
         print("\n".join([str(refgeom.top.residue(ii)) for ii in empty_CGs]))
 
+    fn = _mdcu.str_and_dict.FilenameGenerator(output_desc,ctc_cutoff_Ang,output_dir,graphic_ext)
+
     if figures:
         panelheight = 3
         bar_fig = _figure_overall(n_cols, neighborhoods, ctc_cutoff_Ang,
@@ -974,27 +976,21 @@ def residue_neighborhoods(residues,
                                   plot_atomtypes=plot_atomtypes,
                                   switch_off_Ang=switch_off_Ang)
         if savefiles:
-            fname = "%s.overall@%2.1f_Ang.%s" % (output_desc, ctc_cutoff_Ang, graphic_ext.strip("."))
-            fname = _path.join(output_dir, fname)
-            bar_fig.savefig(fname, dpi=graphic_dpi)
+            bar_fig.savefig(fn.fullpath_overall_fig, dpi=graphic_dpi)
             print("The following files have been created")
-            print(fname)
+            print(fn.fullpath_overall_fig)
 
     neighborhoods = {key:val for key, val in neighborhoods.items() if val is not None}
     # TODO undecided about this
     # TODO this code is repeated in sites...can we abstract this oafa?
     if table_ext is not None and savefiles:
         for ihood in neighborhoods.values():
-            fname = '%s.%s@%2.1f_Ang.%s' % (output_desc,
-                                            ihood.anchor_res_and_fragment_str.replace('*', ""),
-                                            ctc_cutoff_Ang,
-                                            table_ext)
-            fname = _path.join(output_dir, fname)
-
+            fname=fn.fname_per_residue_table(ihood.anchor_res_and_fragment_str, table_ext)
             #TODO can't the frequency_spreadsheet handle this now?
             # TODO this code is repeated in sites...can we abstract this oafa?
             if table_ext=='xlsx':
-                ihood.frequency_spreadsheet(ctc_cutoff_Ang, fname,
+                ihood.frequency_spreadsheet(ctc_cutoff_Ang,
+                                            fname,
                                             switch_off_Ang=switch_off_Ang,
                                             write_interface=False,
                                             by_atomtypes=True,
@@ -1494,14 +1490,14 @@ def interface(
     fn = _mdcu.str_and_dict.FilenameGenerator(output_desc,ctc_cutoff_Ang,output_dir, graphic_ext)
     if savefiles:
         print("The following files have been created")
-        ctc_grp_intf.frequency_spreadsheet(ctc_cutoff_Ang, fn.fname_excel, sort=sort_by_av_ctcs)
-        print(fn.fname_excel)
-        ctc_grp_intf.frequency_str_ASCII_file(ctc_cutoff_Ang, ascii_file=fn.fname_dat)
-        print(fn.fname_dat)
-        ctc_grp_intf.frequency_to_bfactor(ctc_cutoff_Ang, fn.fname_pdb, refgeom[0],
+        ctc_grp_intf.frequency_spreadsheet(ctc_cutoff_Ang, fn.fullpath_overall_excel, sort=sort_by_av_ctcs)
+        print(fn.fullpath_overall_excel)
+        ctc_grp_intf.frequency_str_ASCII_file(ctc_cutoff_Ang, ascii_file=fn.fullpath_overall_dat)
+        print(fn.fullpath_overall_dat)
+        ctc_grp_intf.frequency_to_bfactor(ctc_cutoff_Ang, fn.fullpath_pdb, refgeom[0],
                                           # interface_sign=True
                                           )
-        print(fn.fname_pdb)
+        print(fn.fullpath_pdb)
 
     if figures:
         panelheight = 3
@@ -1551,9 +1547,9 @@ def interface(
 
 
         if savefiles:
-            histofig.savefig(fn.fname_overall, dpi=graphic_dpi, bbox_inches="tight")
-            cmat_fig.savefig(fn.fname_mat)
-            print(fn.fname_mat)
+            histofig.savefig(fn.fullpath_overall_fig, dpi=graphic_dpi, bbox_inches="tight")
+            cmat_fig.savefig(fn.fullpath_matrix)
+            print(fn.fullpath_matrix)
 
         if flareplot:
             flare_frags, flare_labs = fragments_as_residue_idxs, fragment_names # Not sure about what's best here
@@ -1582,8 +1578,8 @@ def interface(
                                                              )
             ifig.tight_layout()
             if savefiles:
-                ifig.savefig(fn.fname_flare,bbox_inches="tight")
-                print(fn.fname_flare)
+                ifig.savefig(fn.fullpath_flare_pdf, bbox_inches="tight")
+                print(fn.fullpath_flare_pdf)
 
         if plot_timedep or separate_N_ctcs:
             myfig = ctc_grp_intf.plot_timedep_ctcs(panelheight,

--- a/mdciao/cli/cli.py
+++ b/mdciao/cli/cli.py
@@ -953,7 +953,7 @@ def residue_neighborhoods(residues,
                                    atom_pair_trajs=[itraj[:, [idx * 2, idx * 2 + 1]] for itraj in at_pair_trajs]
                                    ))
         try:
-            neighborhoods[res_idx] = _mdcctcs.ContactGroup(CPs)
+            neighborhoods[res_idx] = _mdcctcs.ContactGroup(CPs, neighbors_excluded=n_nearest)
         except NotImplementedError as e:
             print(e)
             empty_CGs.append(res_idx)

--- a/mdciao/contacts/contacts.py
+++ b/mdciao/contacts/contacts.py
@@ -2739,7 +2739,8 @@ class ContactGroup(object):
                 label_dotref = self.anchor_res_and_fragment_str_short
                 label_bars = self.partner_res_and_fragment_labels_short
             if sum_freqs:
-                label_dotref += '\nSigma = %2.1f' % sigma  # sum over all bc we did not truncate
+                label_dotref = "\n".join([_mdcu.str_and_dict.latex_superscript_fragments(label_dotref),
+                                          _mdcu.str_and_dict.replace4latex('Sigma = %2.1f' % sigma)])  # sum over all bc we did not truncate
                 jax.plot(_np.nan, _np.nan, 'o',
                          color=self.anchor_fragment_color,
                          label=_mdcu.str_and_dict.latex_superscript_fragments(label_dotref))

--- a/mdciao/contacts/contacts.py
+++ b/mdciao/contacts/contacts.py
@@ -2675,7 +2675,6 @@ class ContactGroup(object):
                            total_freq=None,
                            plot_atomtypes=False,
                            display_sort=False,
-                           n_nearest=None,
                            sum_freqs=True,
                            ):
         r"""
@@ -2702,11 +2701,11 @@ class ContactGroup(object):
             display purposes only (the original order is untouched)
         Returns
         -------
-        jax : :obj:`matplotlib.pyplot.Axes`
+        jax : :obj:`~matplotlib.pyplot.Axes`
 
         """
-        # Base plot
 
+        # Base plot
         if title_label is None and not self.is_neighborhood:
             assert self.name is not None, ("Cannot use a 'nameless' ContactGroup and 'title_label'=None.\n"
                                            "Either instantiate self.name or pass a 'title_label' ")
@@ -2733,7 +2732,7 @@ class ContactGroup(object):
         sigma = _np.sum([ipatch.get_height() for ipatch in jax.patches])
         title = "Contact frequency @%2.1f AA"%ctc_cutoff_Ang
         if self.is_neighborhood:
-            title+="\n%s nearest bonded neighbors excluded\n" % (str(n_nearest).replace("None","no"))
+            title+="\n%s nearest bonded neighbors excluded\n" % (str(self.neighbors_excluded).replace("None","no"))
             label_dotref = self.anchor_res_and_fragment_str
             label_bars = self.partner_res_and_fragment_labels
             if shorten_AAs:
@@ -2771,7 +2770,6 @@ class ContactGroup(object):
         return jax
 
     def plot_neighborhood_freqs(self, ctc_cutoff_Ang,
-                                n_nearest,
                                 switch_off_Ang=None,
                                 color=["tab:blue"],
                                 xmax=None,
@@ -2790,7 +2788,6 @@ class ContactGroup(object):
         Parameters
         ----------
         ctc_cutoff_Ang : float
-        n_nearest : int
         xmax : int, default is None
             Default behaviour is to go to n_ctcs, use this
             parameter to homogenize different calls to this
@@ -2813,7 +2810,7 @@ class ContactGroup(object):
 
         Returns
         -------
-        jax : :obj:`matplotlib.pyplot.Axes`
+        jax : :obj:`~matplotlib.pyplot.Axes`
         """
 
         assert self.is_neighborhood, "This ContactGroup is not a neighborhood, use ContactGroup.plot_freqs_as_bars() instead"
@@ -2821,7 +2818,6 @@ class ContactGroup(object):
         jax = self.plot_freqs_as_bars(ctc_cutoff_Ang,
                                       jax=jax,
                                       xlim=xmax,
-                                      n_nearest=n_nearest,
                                       shorten_AAs=shorten_AAs,
                                       truncate_at=None,
                                       plot_atomtypes=plot_atomtypes,
@@ -2964,7 +2960,6 @@ class ContactGroup(object):
                                     jax=None,
                                     shorten_AAs=False,
                                     ctc_cutoff_Ang=None,
-                                    n_nearest=None,
                                     label_fontsize_factor=1,
                                     max_handles_per_row=4,
                                     defrag=None):
@@ -2991,8 +2986,6 @@ class ContactGroup(object):
             Include in the legend of the plot how much of the
             distribution is below this cutoff. A vertical line
             will be draw at this x-value
-        n_nearest : int, default is None
-            Add a line to the title specifying if any
             nearest bonded neighbors were excluded
         label_fontsize_factor
         max_handles_per_row: int, default is 4
@@ -3028,8 +3021,8 @@ class ContactGroup(object):
         if ctc_cutoff_Ang is not None:
             title_str += "\nresidues within %2.1f $\AA$"%(ctc_cutoff_Ang)
             jax.axvline(ctc_cutoff_Ang,color="k",ls="--",zorder=-1)
-        if n_nearest is not None:
-            title_str += "\n%u nearest bonded neighbors excluded" % (n_nearest)
+        if self.neighbors_excluded not in [None,0]:
+            title_str += "\n%u nearest bonded neighbors excluded" % (self.neighbors_excluded)
         jax.set_title(title_str)
 
         # Base plot

--- a/mdciao/contacts/contacts.py
+++ b/mdciao/contacts/contacts.py
@@ -2783,7 +2783,7 @@ class ContactGroup(object):
         Wrapper around :obj:`ContactGroup.plot_freqs_as_bars`
         for plotting neighborhoods
 
-        #TODO perhaps get rid of the wrapper altoghether. ATM it would break the API
+        #TODO perhaps get rid of the wrapper altogether. ATM it would break the API
 
         Parameters
         ----------

--- a/mdciao/contacts/contacts.py
+++ b/mdciao/contacts/contacts.py
@@ -1675,6 +1675,7 @@ class ContactGroup(object):
                  interface_residxs=None,
                  top=None,
                  name=None,
+                 neighbors_excluded=None,
                  use_AA_when_conslab_is_missing=True,#TODO this is for the interfaces
                  ):
         r"""
@@ -1709,7 +1710,9 @@ class ContactGroup(object):
         self._contacts = list_of_contact_objects
         self._n_ctcs  = len(list_of_contact_objects)
         self._interface_residxs = interface_residxs
+        self._neighbors_excluded = neighbors_excluded
         self._is_interface = False
+        self._is_neighborhood = False
         self._name = name
         if top is None:
             self._top = self._unique_topology_from_ctcs()
@@ -1825,9 +1828,22 @@ class ContactGroup(object):
             else:
                 self._interface_residxs = [[],[]]
 
+            if self.shared_anchor_residue_index is not None:
+                self._is_neighborhood=True
+                if self.neighbors_excluded is None:
+                    raise ValueError("This ContactGroup looks like a neighborhood,\n"
+                                     "(all contacts share the residue %s), "
+                                     "but no 'neighbors_excluded' have been parsed!\n"
+                                     "If you're trying to build a site object,\n"
+                                     "use 'neighbors_excluded'=0', else input right number"
+                                     "'neighbors_excluded'")
 
     #todo again the dicussion about named tuples vs a miriad of properties
-    # I am opting for properties because of easyness of documenting i
+    # I am opting for properties because of easiness of documenting i
+
+    @property
+    def neighbors_excluded(self):
+        return self._neighbors_excluded
 
     @property
     def name(self):
@@ -1987,10 +2003,7 @@ class ContactGroup(object):
 
     @property
     def is_neighborhood(self):
-        if self.shared_anchor_residue_index is None:
-            return False
-        else:
-            return True
+        return self._is_neighborhood
 
     #TODO make this a property at instantiation and build neighborhoods a posteriori?
     @property

--- a/mdciao/contacts/contacts.py
+++ b/mdciao/contacts/contacts.py
@@ -2973,6 +2973,8 @@ class ContactGroup(object):
         Plot distance distributions for the distance trajectories
         of the contacts
 
+        The title will get try to get the name from :obj:`self.name`
+
         Parameters
         ----------
         nbins : int, default is 10
@@ -2998,7 +3000,7 @@ class ContactGroup(object):
 
         Returns
         -------
-        jax : :obj:`matplotlib.pyplot.Axes`
+        jax : :obj:`~matplotlib.pyplot.Axes`
 
         """
         if jax is None:
@@ -3006,20 +3008,23 @@ class ContactGroup(object):
             jax = _plt.gca()
 
         if self.is_neighborhood:
-            label_dotref = self.anchor_res_and_fragment_str
+            title = self.anchor_res_and_fragment_str
             label_bars = self.partner_res_and_fragment_labels
             if shorten_AAs:
-                label_dotref = self.anchor_res_and_fragment_str_short
+                title = self.anchor_res_and_fragment_str_short
                 label_bars = self.partner_res_and_fragment_labels_short
         else:
-            label_dotref = self.name
+            title = self.name
+            if title is None:
+                title = self.__class__.__name__
             label_bars = self.ctc_labels_w_fragments_short_AA
 
         if defrag is not None:
-            label_dotref = _mdcu.str_and_dict.defrag_key(label_dotref,defrag=defrag)
+            title = _mdcu.str_and_dict.defrag_key(title,defrag=defrag)
             label_bars = [_mdcu.str_and_dict.defrag_key(ilab,defrag=defrag) for ilab in label_bars]
+
         # Cosmetics
-        title_str = "distribution for %s"%_mdcu.str_and_dict.latex_superscript_fragments(label_dotref)
+        title_str = "distribution for %s"%_mdcu.str_and_dict.latex_superscript_fragments(title)
         if ctc_cutoff_Ang is not None:
             title_str += "\nresidues within %2.1f $\AA$"%(ctc_cutoff_Ang)
             jax.axvline(ctc_cutoff_Ang,color="k",ls="--",zorder=-1)

--- a/mdciao/utils/str_and_dict.py
+++ b/mdciao/utils/str_and_dict.py
@@ -971,30 +971,61 @@ class FilenameGenerator(object):
 
     def __init__(self,output_desc,ctc_cutoff_Ang,output_dir,graphic_ext):
 
-        graphic_ext = graphic_ext.strip(".")
-        fname_wo_ext = "%s.overall@%2.1f_Ang" % (output_desc.replace(" ", "_"), ctc_cutoff_Ang)
-        self.base_fname = _path.join(output_dir, fname_wo_ext)
-        self.graphic_ext = graphic_ext.strip(".")
+        self._graphic_ext = graphic_ext.strip(".")
+        self._output_desc = output_desc
+        self._ctc_cutoff_Ang = ctc_cutoff_Ang
+        self._output_dir = output_dir
 
     @property
-    def fname_overall(self):
-        return ".".join([self.base_fname, self.graphic_ext])
+    def output_dir(self):
+        return self._output_dir
     @property
-    def fname_excel(self):
-        return ".".join([self.base_fname, "xlsx"])
+    def basename_wo_ext(self):
+        return "%s.overall@%2.1f_Ang" % (self.output_desc,
+                                         self.ctc_cutoff_Ang)
+    @property
+    def ctc_cutoff_Ang(self):
+        return self._ctc_cutoff_Ang
 
     @property
-    def fname_dat(self):
-        return ".".join([self.base_fname, "dat"])
+    def output_desc(self):
+        return self._output_desc.replace(" ","_")
 
     @property
-    def fname_pdb(self):
-        return ".".join([self.base_fname, "as_bfactors.pdb"])
+    def fullpath_overall_no_ext(self):
+        return _path.join(self.output_dir, self.basename_wo_ext)
 
     @property
-    def fname_mat(self):
-        return self.fname_overall.replace("overall@", "matrix@")
+    def graphic_ext(self):
+        return self._graphic_ext
 
     @property
-    def fname_flare(self):
-        return '.'.join([self.base_fname.replace("overall@", "flare@"), 'pdf'])
+    def fullpath_overall_fig(self):
+        return ".".join([self.fullpath_overall_no_ext, self.graphic_ext])
+
+    def fname_per_residue_table(self,istr, table_ext):
+        fname = '%s.%s@%2.1f_Ang.%s' % (self.output_desc,
+                                        istr.replace('*', ""),
+                                        self.ctc_cutoff_Ang,
+                                        table_ext)
+        return _path.join(self.output_dir, fname)
+
+    @property
+    def fullpath_overall_excel(self):
+        return ".".join([self.fullpath_overall_no_ext, "xlsx"])
+
+    @property
+    def fullpath_overall_dat(self):
+        return ".".join([self.fullpath_overall_no_ext, "dat"])
+
+    @property
+    def fullpath_pdb(self):
+        return ".".join([self.fullpath_overall_no_ext, "as_bfactors.pdb"])
+
+    @property
+    def fullpath_matrix(self):
+        return self.fullpath_overall_fig.replace("overall@", "matrix@")
+
+    @property
+    def fullpath_flare_pdf(self):
+        return '.'.join([self.fullpath_overall_no_ext.replace("overall@", "flare@"), 'pdf'])

--- a/mdciao/utils/str_and_dict.py
+++ b/mdciao/utils/str_and_dict.py
@@ -973,28 +973,28 @@ class FilenameGenerator(object):
 
         graphic_ext = graphic_ext.strip(".")
         fname_wo_ext = "%s.overall@%2.1f_Ang" % (output_desc.replace(" ", "_"), ctc_cutoff_Ang)
-        self.fname_wo_ext = _path.join(output_dir, fname_wo_ext)
+        self.base_fname = _path.join(output_dir, fname_wo_ext)
         self.graphic_ext = graphic_ext.strip(".")
 
     @property
-    def fname_histo(self):
-        return ".".join([self.fname_wo_ext, self.graphic_ext])
+    def fname_overall(self):
+        return ".".join([self.base_fname, self.graphic_ext])
     @property
     def fname_excel(self):
-        return ".".join([self.fname_wo_ext, "xlsx"])
+        return ".".join([self.base_fname, "xlsx"])
 
     @property
     def fname_dat(self):
-        return ".".join([self.fname_wo_ext, "dat"])
+        return ".".join([self.base_fname, "dat"])
 
     @property
     def fname_pdb(self):
-        return ".".join([self.fname_wo_ext, "as_bfactors.pdb"])
+        return ".".join([self.base_fname, "as_bfactors.pdb"])
 
     @property
     def fname_mat(self):
-        return self.fname_histo.replace("overall@", "matrix@")
+        return self.fname_overall.replace("overall@", "matrix@")
 
     @property
     def fname_flare(self):
-        return '.'.join([self.fname_wo_ext.replace("overall@", "flare@"), 'pdf'])
+        return '.'.join([self.base_fname.replace("overall@", "flare@"), 'pdf'])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,7 @@ class Test_manage_timdep_plot_options(TestCLTBaseClass):
 
         cls.ctc_grp = contacts.ContactGroup(CPs,
                                             top=cls.geom.top,
+                                            neighbors_excluded=0,
                                             )
 
     """

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1559,23 +1559,23 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
     def test_plot_neighborhood_raises(self):
         CG = self.CG_cp1_cp2
         with pytest.raises(AssertionError):
-            CG.plot_neighborhood_freqs(2, 0)
+            CG.plot_neighborhood_freqs(2)
 
     def test_plot_neighborhood_works_minimal(self):
         CG = self.CG_cp1_cp2_both_w_anchor_and_frags
-        jax = CG.plot_neighborhood_freqs(2, 0)
+        jax = CG.plot_neighborhood_freqs(2)
         assert isinstance(jax, _plt.Axes)
         _plt.close("all")
 
     def test_plot_neighborhood_works_options(self):
         CG = self.CG_cp1_cp2_both_w_anchor_and_frags
-        jax = CG.plot_neighborhood_freqs(2, 0, shorten_AAs=True)
+        jax = CG.plot_neighborhood_freqs(2, shorten_AAs=True)
         assert isinstance(jax, _plt.Axes)
-        jax = CG.plot_neighborhood_freqs(2, 0, xmax=10)
+        jax = CG.plot_neighborhood_freqs(2,xmax=10)
         assert isinstance(jax, _plt.Axes)
         _plt.plot()
         jax = _plt.gca()
-        assert jax is CG.plot_neighborhood_freqs(2, 0, jax=jax)
+        assert jax is CG.plot_neighborhood_freqs(2, jax=jax)
         _plt.close("all")
 
     def test_plot_get_hatches_for_plotting_atomtypes(self):
@@ -1636,8 +1636,7 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
         CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         jax = CG.plot_distance_distributions(shorten_AAs=True,
                                              ctc_cutoff_Ang=3,
-                                             xlim=[-1, 5],
-                                             n_nearest=1)
+                                             xlim=[-1, 5])
         assert isinstance(jax, _plt.Axes)
         _plt.close("all")
 
@@ -1646,7 +1645,7 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
             jax = CG.plot_distance_distributions(shorten_AAs=True,
                                                  ctc_cutoff_Ang=3,
                                                  xlim=[-1, 5],
-                                                 n_nearest=1)
+                                                )
             assert isinstance(jax, _plt.Axes)
             _plt.close("all")
 
@@ -1655,7 +1654,6 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
             jax = CG.plot_distance_distributions(shorten_AAs=True,
                                                  ctc_cutoff_Ang=3,
                                                  xlim=[-1, 5],
-                                                 n_nearest=1,
                                                  defrag="@")
             assert isinstance(jax, _plt.Axes)
             _plt.close("all")

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1735,12 +1735,19 @@ class TestContactGroupASCII(TestBaseClassContactGroup):
             newfreq = freq_file2dict(tfile)
             _np.testing.assert_array_equal(list(newfreq.values()),CG.frequency_per_contact(2.5))
 
-
 class TestContactGroupTrajdicts(TestBaseClassContactGroup):
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestContactGroupTrajdicts,cls).setUp(cls)
+        cls.CG = contacts.ContactGroup(
+            [cls.cp1_w_anchor_and_frags_and_top,
+             cls.cp2_w_anchor_and_frags_and_top],
+            neighbors_excluded=0
+        )
+
     def test_to_per_traj_dicts_for_saving(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         list_of_dicts = CG._to_per_traj_dicts_for_saving()
 
         data_traj_0 = list_of_dicts[0]["data"]
@@ -1758,8 +1765,7 @@ class TestContactGroupTrajdicts(TestBaseClassContactGroup):
                                        self.cp2_w_anchor_and_frags_and_top.time_traces.ctc_trajs[1] * 10)
 
     def test_to_per_traj_dicts_for_saving_with_tunits_ns(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         list_of_dicts = CG._to_per_traj_dicts_for_saving(t_unit="ns")
 
         data_traj_0 = list_of_dicts[0]["data"]
@@ -1771,8 +1777,7 @@ class TestContactGroupTrajdicts(TestBaseClassContactGroup):
                                        self.cp1_w_anchor_and_frags_and_top.time_traces.time_trajs[1] * 1e-3)
 
     def test_to_per_traj_dicts_for_saving_with_tunits_mus(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         list_of_dicts = CG._to_per_traj_dicts_for_saving(t_unit="mus")
 
         data_traj_0 = list_of_dicts[0]["data"]
@@ -1784,8 +1789,7 @@ class TestContactGroupTrajdicts(TestBaseClassContactGroup):
                                        self.cp1_w_anchor_and_frags_and_top.time_traces.time_trajs[1] * 1e-6)
 
     def test_to_per_traj_dicts_for_saving_with_tunits_ms(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         list_of_dicts = CG._to_per_traj_dicts_for_saving(t_unit="ms")
 
         data_traj_0 = list_of_dicts[0]["data"]
@@ -1797,8 +1801,7 @@ class TestContactGroupTrajdicts(TestBaseClassContactGroup):
                                        self.cp1_w_anchor_and_frags_and_top.time_traces.time_trajs[1] * 1e-9)
 
     def test_to_per_traj_dicts_for_saving_with_tunits_raises(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         with pytest.raises(ValueError):
             list_of_dicts = CG._to_per_traj_dicts_for_saving(t_unit="fs")
 

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1714,18 +1714,19 @@ class TestContactGroupSpreadsheet(TestBaseClassContactGroup):
             with _TDir(suffix='_test_mdciao') as tmpdir:
                 CG.frequency_spreadsheet(2.5, path.join(tmpdir, "test.xlsx"))
 
-
 class TestContactGroupASCII(TestBaseClassContactGroup):
-    def test_frequency_str_ASCII_file(self):
+    def test_frequency_str_ASCII_file_str(self):
         CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+                                    self.cp2_w_anchor_and_frags_and_top],
+                                   neighbors_excluded=0)
         istr = CG.frequency_str_ASCII_file(2.5, by_atomtypes=False)
         self.assertEqual(istr[0], "#")
         self.assertIsInstance(istr, str)
 
     def test_frequency_str_ASCII_file(self):
         CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+                                    self.cp2_w_anchor_and_frags_and_top],
+                                   neighbors_excluded=0)
 
         with _TDir() as tmpdir:
             tfile = path.join(tmpdir,'freqfile.dat')

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1687,12 +1687,12 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
                                               label_type="blergh")
         _plt.close("all")
 
-
 class TestContactGroupSpreadsheet(TestBaseClassContactGroup):
 
     def test_frequency_spreadsheedt_just_works(self):
         CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+                                    self.cp2_w_anchor_and_frags_and_top],
+                                   neighbors_excluded=0)
         with _TDir(suffix='_test_mdciao') as tmpdir:
             CG.frequency_spreadsheet(2.5, path.join(tmpdir, "test.xlsx"),
                                      write_interface=False)
@@ -1708,7 +1708,8 @@ class TestContactGroupSpreadsheet(TestBaseClassContactGroup):
 
     def test_frequency_spreadsheet_raises_w_interface(self):
         CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+                                    self.cp2_w_anchor_and_frags_and_top],
+                                   neighbors_excluded=0)
         with pytest.raises(AssertionError):
             with _TDir(suffix='_test_mdciao') as tmpdir:
                 CG.frequency_spreadsheet(2.5, path.join(tmpdir, "test.xlsx"))

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1010,8 +1010,6 @@ class TestBaseClassContactGroup(unittest.TestCase):
         #At 3.5, the above cp1 gives SC-BB, BB-BB, BB-BB:
         # 2/3 BB-BB, 1/3 SC-BB
 
-
-
 class TestContactGroup(TestBaseClassContactGroup):
 
 
@@ -1465,34 +1463,43 @@ class TestContactGroupFrequencies(TestBaseClassContactGroup):
         _np.testing.assert_equal(table["by_atomtypes"][0], "(66% BB-BB, 33% BB-SC)")
         _np.testing.assert_equal(table["by_atomtypes"][1], "(66% BB-SC, 33% SC-BB)")
 
-
 class TestContactGroupPlots(TestBaseClassContactGroup):
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestContactGroupPlots,cls).setUp(cls)
+        cls.CG_cp1_cp2 = contacts.ContactGroup([cls.cp1, cls.cp2])
+        cls.CG_cp1_cp2_both_w_anchor_and_frags = contacts.ContactGroup(
+            [cls.cp1_w_anchor_and_frags,
+             cls.cp2_w_anchor_and_frags],
+            neighbors_excluded=0
+        )
+
     def test_plot_freqs_as_bars_just_runs(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         jax = CG.plot_freqs_as_bars(2, "test_site")
         assert isinstance(jax, _plt.Axes)
         _plt.close("all")
 
     def test_plot_freqs_as_bars_just_runs_labels_short(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         jax = CG.plot_freqs_as_bars(2, "test_site", shorten_AAs=True)
         assert isinstance(jax, _plt.Axes)
         _plt.close("all")
 
     def test_plot_freqs_as_bars_just_runs_labels_xlim(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         jax = CG.plot_freqs_as_bars(2, "test_site", xlim=20)
         assert isinstance(jax, _plt.Axes)
         _plt.close("all")
 
     def test_plot_freqs_as_bars_display_sort(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         CG.plot_freqs_as_bars(2, "test_site", display_sort=True)
 
 
     def test_plot_freqs_as_bars_total_freq(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         CG.plot_freqs_as_bars(2, "test_site", total_freq=CG.frequency_per_contact(2).sum())
 
     def test_plot_freqs_as_bars_no_neighborhood(self):
@@ -1503,7 +1510,7 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
 
     def test_plot_freqs_as_bars_no_neighborhood_fails(self):
         with pytest.raises(AssertionError):
-            CG = contacts.ContactGroup([self.cp1, self.cp2])
+            CG = self.CG_cp1_cp2
             CG.plot_freqs_as_bars(2,)
 
     def test_plot_add_hatching_by_atomtypes(self):
@@ -1550,20 +1557,18 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
 
 
     def test_plot_neighborhood_raises(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         with pytest.raises(AssertionError):
             CG.plot_neighborhood_freqs(2, 0)
 
     def test_plot_neighborhood_works_minimal(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags])
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         jax = CG.plot_neighborhood_freqs(2, 0)
         assert isinstance(jax, _plt.Axes)
         _plt.close("all")
 
     def test_plot_neighborhood_works_options(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags])
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         jax = CG.plot_neighborhood_freqs(2, 0, shorten_AAs=True)
         assert isinstance(jax, _plt.Axes)
         jax = CG.plot_neighborhood_freqs(2, 0, xmax=10)
@@ -1582,20 +1587,16 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
 
 
     def test_plot_timedep_ctcs(self):
-        from matplotlib.pyplot import Figure
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags])
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         figs = CG.plot_timedep_ctcs(1)
         _np.testing.assert_equal(len(figs), 1)
-        assert isinstance(figs[0], Figure)
-        ifig: Figure = figs[0]
+        assert isinstance(figs[0], _plt.Figure)
+        ifig = figs[0]
         _np.testing.assert_equal(len(ifig.axes), 2 + 1)  # 2 + twinx
         _plt.close("all")
 
     def test_plot_timedep_ctcs_with_valid_cutoff_no_pop(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         figs = CG.plot_timedep_ctcs(1, ctc_cutoff_Ang=1)
         ifig = figs[0]
         _np.testing.assert_equal(len(figs), 1)
@@ -1603,9 +1604,7 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
         _plt.close("all")
 
     def test_plot_timedep_ctcs_with_valid_cutoff_w_pop(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         figs = CG.plot_timedep_ctcs(1, ctc_cutoff_Ang=1,
                                     pop_N_ctcs=True)
         _np.testing.assert_equal(len(figs), 2)
@@ -1614,17 +1613,13 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
         _plt.close("all")
 
     def test_plot_timedep_ctcs_skip_empty(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         figs = CG.plot_timedep_ctcs(1, skip_timedep=True)
         _np.testing.assert_equal(len(figs), 0)
         _plt.close("all")
 
     def test_plot_timedep_ctcs_skip_w_valid_cutoff(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         figs = CG.plot_timedep_ctcs(1, ctc_cutoff_Ang=1,
                                     skip_timedep=True)
         _np.testing.assert_equal(len(figs), 1)
@@ -1632,18 +1627,13 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
         _plt.close("all")
 
     def test_plot_neighborhood_distributions_just_works(self):
-        from matplotlib.pyplot import Axes
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         jax = CG.plot_distance_distributions()
-        assert isinstance(jax, Axes)
+        assert isinstance(jax, _plt.Axes)
         _plt.close("all")
 
     def test_plot_neighborhood_distributions_just_works_w_options(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         jax = CG.plot_distance_distributions(shorten_AAs=True,
                                              ctc_cutoff_Ang=3,
                                              xlim=[-1, 5],
@@ -1652,17 +1642,13 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
         _plt.close("all")
 
     def test_plot_frequency_sums_as_bars_just_works(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         jax = CG.plot_frequency_sums_as_bars(2.0, "test", xmax=4)
         assert isinstance(jax, _plt.Axes)
         _plt.close("all")
 
     def test_plot_frequency_sums_as_bars_no_interface_raises(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         with pytest.raises(AssertionError):
             jax = CG.plot_frequency_sums_as_bars(2.0, "test", list_by_interface=True)
 

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1805,12 +1805,19 @@ class TestContactGroupTrajdicts(TestBaseClassContactGroup):
         with pytest.raises(ValueError):
             list_of_dicts = CG._to_per_traj_dicts_for_saving(t_unit="fs")
 
-
 class TestContactGroupBintrajdicts(TestBaseClassContactGroup):
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestContactGroupBintrajdicts,cls).setUp(cls)
+        cls.CG = contacts.ContactGroup(
+            [cls.cp1_w_anchor_and_frags_and_top,
+             cls.cp2_w_anchor_and_frags_and_top],
+            neighbors_excluded=0
+        )
+
     def test_to_per_traj_dicts_for_saving_bintrajs(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         list_of_dicts = CG._to_per_traj_dicts_for_saving_bintrajs(2.5)
         bintrajs_per_traj = CG.binarize_trajs(2.5, order="traj")
 
@@ -1829,8 +1836,7 @@ class TestContactGroupBintrajdicts(TestBaseClassContactGroup):
                                        bintrajs_per_traj[1][:, 1])
 
     def test_to_per_traj_dicts_for_saving_bintrajs_ns(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         list_of_dicts = CG._to_per_traj_dicts_for_saving_bintrajs(2.5, t_unit="ns")
 
         data_traj_0 = list_of_dicts[0]["data"]
@@ -1842,8 +1848,7 @@ class TestContactGroupBintrajdicts(TestBaseClassContactGroup):
                                        self.cp1_w_anchor_and_frags_and_top.time_traces.time_trajs[1] * 1e-3)
 
     def test_to_per_traj_dicts_for_saving_bintrajs_mus(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         list_of_dicts = CG._to_per_traj_dicts_for_saving_bintrajs(2.5, t_unit="mus")
 
         data_traj_0 = list_of_dicts[0]["data"]
@@ -1855,8 +1860,7 @@ class TestContactGroupBintrajdicts(TestBaseClassContactGroup):
                                        self.cp1_w_anchor_and_frags_and_top.time_traces.time_trajs[1] * 1e-6)
 
     def test_to_per_traj_dicts_for_saving_bintrajs_ms(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         list_of_dicts = CG._to_per_traj_dicts_for_saving_bintrajs(2.5, t_unit="ms")
 
         data_traj_0 = list_of_dicts[0]["data"]
@@ -1868,8 +1872,7 @@ class TestContactGroupBintrajdicts(TestBaseClassContactGroup):
                                        self.cp1_w_anchor_and_frags_and_top.time_traces.time_trajs[1] * 1e-9)
 
     def test_to_per_traj_dicts_for_saving_bintrajs_tunits_raises(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CG = self.CG
         with pytest.raises(ValueError):
             list_of_dicts = CG._to_per_traj_dicts_for_saving_bintrajs(2.5, t_unit="fs")
 

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1014,40 +1014,40 @@ class TestBaseClassContactGroup(unittest.TestCase):
 
 class TestContactGroup(TestBaseClassContactGroup):
 
-    def test_works_minimal(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+
+    def setUp(self):
+        super(TestContactGroup, self).setUp()
+        # test_works_minimal no top
+        self.CG_cp1_cp2 = contacts.ContactGroup([self.cp1, self.cp2])
+        assert self.CG_cp1_cp2.topology is self.CG_cp1_cp2.top is None
+
+        # test_works_minimal_w top
+        self.CG_cp1_wtop_cp2_wtop = contacts.ContactGroup([self.cp1_wtop, self.cp2_wtop], top=self.top)
+        assert self.CG_cp1_wtop_cp2_wtop.topology is self.CG_cp1_wtop_cp2_wtop.top is self.top
 
     def test_works_minimal_top_raises(self):
         with pytest.raises(AssertionError):
-            CG = contacts.ContactGroup([self.cp1, self.cp2], top=self.top)
-
-    def test_works_minimal_top_works(self):
-        CG = contacts.ContactGroup([self.cp1_wtop, self.cp2_wtop], top=self.top)
+            contacts.ContactGroup([self.cp1, self.cp2], top=self.top)
 
     def test_n_properties(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         _np.testing.assert_equal(CG.n_ctcs, 2)
         _np.testing.assert_equal(CG.n_trajs, 2)
         _np.testing.assert_array_equal(CG.n_frames, [3, 1])
 
     def test_time_properties(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         _np.testing.assert_equal(3, CG.time_max)
         _np.testing.assert_array_equal([1, 2, 3], CG.time_arrays[0])
         _np.testing.assert_array_equal([1], CG.time_arrays[1])
 
-    def test_tops(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
-        assert CG.topology is CG.top is None
-        CG = contacts.ContactGroup([self.cp1_wtop, self.cp2_wtop])
-        assert CG.topology is CG.top is self.top
-
+    def test_wrong_top_raises(self):
         with pytest.raises(ValueError):
             contacts.ContactGroup([self.cp1_wtop, self.cp2_wtop,
                                    self.cp3_wtop_other])
 
     def test_Residues(self):
-        CG = contacts.ContactGroup([self.cp1_wtop, self.cp2_wtop])
+        CG = self.CG_cp1_wtop_cp2_wtop
         _np.testing.assert_array_equal([[0, 1],
                                         [0, 2]],
                                        CG.res_idxs_pairs)
@@ -1058,7 +1058,7 @@ class TestContactGroup(TestBaseClassContactGroup):
         _np.testing.assert_equal(CG.residue_names_short[1][1], "W32")
 
     def test_labels(self):
-        CG = contacts.ContactGroup([self.cp1_wtop, self.cp2_wtop])
+        CG = self.CG_cp1_wtop_cp2_wtop
         _np.testing.assert_equal(CG.ctc_labels[0], "GLU30-VAL31")
         _np.testing.assert_equal(CG.ctc_labels[1], "GLU30-TRP32")
         _np.testing.assert_equal(CG.ctc_labels_short[0], "E30-V31")
@@ -1139,7 +1139,9 @@ class TestContactGroup(TestBaseClassContactGroup):
 
     def test_fragment_names_best_fragnames(self):
         CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags])
+                                    self.cp2_w_anchor_and_frags],
+                                   neighbors_excluded=0
+                                   )
 
         _np.testing.assert_array_equal(CG.fragment_names_best[0], ["fragA", "fragB"])
         _np.testing.assert_array_equal(CG.fragment_names_best[1], ["fragA", "fragC"])
@@ -1158,7 +1160,7 @@ class TestContactGroup(TestBaseClassContactGroup):
                                    self.cp3_wtop_and_wrong_conslabs])
 
     def test_neighborhoods_raises(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         _np.testing.assert_equal(CG.shared_anchor_residue_index, None)
         with pytest.raises(AssertionError):
             CG.anchor_res_and_fragment_str
@@ -1175,7 +1177,9 @@ class TestContactGroup(TestBaseClassContactGroup):
 
     def test_neighborhoods(self):
         CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags])
+                                    self.cp2_w_anchor_and_frags],
+                                   neighbors_excluded=0
+                                   )
         assert CG.is_neighborhood
         _np.testing.assert_equal(CG.shared_anchor_residue_index, 0)
         _np.testing.assert_equal(CG.anchor_res_and_fragment_str, "0@fragA")
@@ -1188,18 +1192,24 @@ class TestContactGroup(TestBaseClassContactGroup):
 
     def test_neighborhood_w_partner_color(self):
         CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
-                                    self.cp2_w_anchor_and_frags])
+                                    self.cp2_w_anchor_and_frags],
+                                   neighbors_excluded=0
+                                   )
         _np.testing.assert_array_equal(["b", "g"], CG.partner_fragment_colors)
 
     def test_neighborhoods_wrong_anchor_color(self):
         CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags,
                                     self.cp2_w_anchor_and_frags,
-                                    self.cp3_w_anchor_and_frags_wrong_anchor_color])
+                                    self.cp3_w_anchor_and_frags_wrong_anchor_color],
+                                   neighbors_excluded=0
+                                   )
         assert CG.anchor_fragment_color is None
 
     def test_neighborhoods_w_top(self):
         CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+                                    self.cp2_w_anchor_and_frags_and_top],
+                                   neighbors_excluded=0
+                                   )
         _np.testing.assert_equal(CG.shared_anchor_residue_index, 0)
         _np.testing.assert_equal(CG.anchor_res_and_fragment_str, "GLU30@fragA")
         _np.testing.assert_equal(CG.anchor_res_and_fragment_str_short, "E30@fragA")
@@ -1209,14 +1219,14 @@ class TestContactGroup(TestBaseClassContactGroup):
         _np.testing.assert_equal(CG.partner_res_and_fragment_labels_short[1], "W32@fragC")
 
     def test_residx2ctcidx(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         _np.testing.assert_array_equal(CG.residx2ctcidx(1), [[0, 1]])
         _np.testing.assert_array_equal(CG.residx2ctcidx(2), [[1, 1]])
         _np.testing.assert_array_equal(CG.residx2ctcidx(0), [[0, 0],
                                                              [1, 0]])
 
     def test_binarize_trajs(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         bintrajs = CG.binarize_trajs(2.5)
         _np.testing.assert_array_equal([1, 1, 0], bintrajs[0][0])
         _np.testing.assert_array_equal([0], bintrajs[0][1])
@@ -1244,7 +1254,7 @@ class TestContactGroup(TestBaseClassContactGroup):
         _np.testing.assert_array_equal([0], traj_2_ctc_3)
 
     def test_distance_distributions(self):
-        CG = contacts.ContactGroup([self.cp1, self.cp2])
+        CG = self.CG_cp1_cp2
         h1, x1 = self.cp1.distro_overall_trajs(bins=10)
         h2, x2 = self.cp2.distro_overall_trajs(bins=10)
         distros = CG.distributions_of_distances(nbins=10)

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1280,25 +1280,30 @@ class TestContactGroup(TestBaseClassContactGroup):
             CP.plot_interface_frequency_matrix(None)
         assert CP.interface_frequency_matrix(None) is None
 
-
 class TestContactGroupFrequencies(TestBaseClassContactGroup):
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestContactGroupFrequencies,cls).setUp(cls)
+        cls.CG = contacts.ContactGroup(
+            [cls.cp1_w_anchor_and_frags_and_top,
+             cls.cp2_w_anchor_and_frags_and_top],
+            neighbors_excluded=0
+        )
+
     def test_frequency_dict(self):
-        CP = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CP = self.CG
         freqdcit = CP.frequency_dict(2, split_label=False)
         self.assertDictEqual(freqdcit, {"E30@fragA-V31@fragB" : 2 / 5,
                                         "E30@fragA-W32@fragC" : 1 / 5})
 
     def test_frequency_per_contact(self):
-        CP = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CP = self.CG
         freqs = CP.frequency_per_contact(2)
         _np.testing.assert_array_equal([2 / 5, 1 / 5], freqs)
 
     def test_frequency_per_residue_idx(self):
-        CP = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CP = self.CG
         freq_dict = CP.frequency_sum_per_residue_idx_dict(2)
         assert len(freq_dict) == 3
         _np.testing.assert_equal(freq_dict[0], 2 / 5 + 1 / 5)
@@ -1306,16 +1311,14 @@ class TestContactGroupFrequencies(TestBaseClassContactGroup):
         _np.testing.assert_equal(freq_dict[2], 1 / 5)
 
     def test_frequency_per_residue_idx_return_array(self):
-        CP = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CP = self.CG
         freq_dict = CP.frequency_sum_per_residue_idx_dict(2)
         freq_array = CP.frequency_sum_per_residue_idx_dict(2, return_array=True)
         _np.testing.assert_array_equal(list(freq_dict.values()),freq_array[freq_array>0])
 
 
     def test_frequency_per_residue_name(self):
-        CP = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CP = self.CG
         freq_dict = CP.frequency_sum_per_residue_names_dict(2)
         assert len(freq_dict) == 3
         _np.testing.assert_equal(freq_dict["E30@fragA"], 2 / 5 + 1 / 5)
@@ -1323,8 +1326,7 @@ class TestContactGroupFrequencies(TestBaseClassContactGroup):
         _np.testing.assert_equal(freq_dict["W32@fragC"], 1 / 5)
 
     def test_frequency_per_residue_name_no_sort(self):
-        CP = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CP = self.CG
         freq_dict = CP.frequency_sum_per_residue_names_dict(2, sort=False)
         assert len(freq_dict) == 3
         _np.testing.assert_equal(freq_dict["E30@fragA"], 2 / 5 + 1 / 5)
@@ -1332,8 +1334,7 @@ class TestContactGroupFrequencies(TestBaseClassContactGroup):
         _np.testing.assert_equal(freq_dict["W32@fragC"], 1 / 5)
 
     def test_frequency_per_residue_name_dataframe(self):
-        CP = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CP = self.CG
         freq_dict = CP.frequency_sum_per_residue_names_dict(2,
                                                             return_as_dataframe=True)
         assert len(freq_dict) == 3
@@ -1343,15 +1344,13 @@ class TestContactGroupFrequencies(TestBaseClassContactGroup):
                                                                  1 / 5])
 
     def test_frequency_per_residue_name_interface_raises(self):
-        CP = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CP = self.CG
         with pytest.raises(AssertionError):
             CP.frequency_sum_per_residue_names_dict(2,
                                                     list_by_interface=True)
 
     def test_frequency_dict_by_consensus_labels_fails(self):
-        CP = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top])
+        CP = self.CG
 
         with pytest.raises(AssertionError):
             CP.frequency_dict_by_consensus_labels(2)

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1626,13 +1626,13 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
         _np.testing.assert_equal(len(figs[0].axes), 1)  # Just nctc
         _plt.close("all")
 
-    def test_plot_neighborhood_distributions_just_works(self):
+    def test_plot_distance_distributions_just_works(self):
         CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         jax = CG.plot_distance_distributions()
         assert isinstance(jax, _plt.Axes)
         _plt.close("all")
 
-    def test_plot_neighborhood_distributions_just_works_w_options(self):
+    def test_plot_plot_distance_distributions_just_works_w_options(self):
         CG = self.CG_cp1_cp2_both_w_anchor_and_frags
         jax = CG.plot_distance_distributions(shorten_AAs=True,
                                              ctc_cutoff_Ang=3,
@@ -1640,6 +1640,25 @@ class TestContactGroupPlots(TestBaseClassContactGroup):
                                              n_nearest=1)
         assert isinstance(jax, _plt.Axes)
         _plt.close("all")
+
+    def test_plot_plot_distance_distributions_no_neighborhood(self):
+            CG = self.CG_cp1_cp2
+            jax = CG.plot_distance_distributions(shorten_AAs=True,
+                                                 ctc_cutoff_Ang=3,
+                                                 xlim=[-1, 5],
+                                                 n_nearest=1)
+            assert isinstance(jax, _plt.Axes)
+            _plt.close("all")
+
+    def test_plot_plot_distance_distributions_no_neighborhood_defrag(self):
+            CG = self.CG_cp1_cp2
+            jax = CG.plot_distance_distributions(shorten_AAs=True,
+                                                 ctc_cutoff_Ang=3,
+                                                 xlim=[-1, 5],
+                                                 n_nearest=1,
+                                                 defrag="@")
+            assert isinstance(jax, _plt.Axes)
+            _plt.close("all")
 
     def test_plot_frequency_sums_as_bars_just_works(self):
         CG = self.CG_cp1_cp2_both_w_anchor_and_frags
@@ -1941,7 +1960,6 @@ class TestContactGroupSavetrajs(TestBaseClassContactGroup):
             CG.save_trajs("test_None", "dat", verbose=True, t_unit="ns",
                           ctc_cutoff_Ang=2.5,
                           output_dir=tempdir)
-
 
 class TestContactGroupInterface(TestBaseClassContactGroup):
 

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1876,59 +1876,58 @@ class TestContactGroupBintrajdicts(TestBaseClassContactGroup):
         with pytest.raises(ValueError):
             list_of_dicts = CG._to_per_traj_dicts_for_saving_bintrajs(2.5, t_unit="fs")
 
-
 class TestContactGroupSavetrajs(TestBaseClassContactGroup):
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestContactGroupSavetrajs,cls).setUp(cls)
+        cls.CG_cp1_cp2_both_w_anchor_and_frags_and_top = contacts.ContactGroup(
+            [cls.cp1_w_anchor_and_frags_and_top,
+             cls.cp2_w_anchor_and_frags_and_top],
+            neighbors_excluded=0
+        )
+        cls.CG_cp1_cp2_both_wtop_and_conslabs = contacts.ContactGroup(
+            [cls.cp1_wtop_and_conslabs,
+             cls.cp2_wtop_and_conslabs])
     def test_save_trajs_no_anchor(self):
-        CG = contacts.ContactGroup([self.cp1_wtop_and_conslabs,
-                                    self.cp2_wtop_and_conslabs])
+        CG = self.CG_cp1_cp2_both_wtop_and_conslabs
         with _TDir(suffix='_test_mdciao') as tempdir:
             CG.save_trajs("test", "dat", verbose=True, t_unit="ns",
                           output_dir=tempdir)
 
     def test_save_trajs_no_anchor_npy(self):
-        CG = contacts.ContactGroup([self.cp1_wtop_and_conslabs,
-                                    self.cp2_wtop_and_conslabs])
+        CG = self.CG_cp1_cp2_both_wtop_and_conslabs
         with _TDir(suffix='_test_mdciao') as tempdir:
             CG.save_trajs("test", "npy", verbose=True, t_unit="ns",
                           output_dir=tempdir)
 
 
     def test_save_trajs_w_anchor(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags_and_top
         with _TDir(suffix='_test_mdciao') as tempdir:
             CG.save_trajs("test", "dat", verbose=True, t_unit="ns",
                           output_dir=tempdir)
 
     def test_save_trajs_no_anchor_excel(self):
-        CG = contacts.ContactGroup([self.cp1_wtop_and_conslabs,
-                                    self.cp2_wtop_and_conslabs])
+        CG = self.CG_cp1_cp2_both_wtop_and_conslabs
         with _TDir(suffix='_test_mdciao') as tempdir:
             CG.save_trajs("test", "xlsx", verbose=True, t_unit="ns",
                           output_dir=tempdir)
 
     def test_save_trajs_w_anchor_excel(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags_and_top
         with _TDir(suffix='_test_mdciao') as tempdir:
             CG.save_trajs("test", "xlsx", verbose=True, t_unit="ns",
                           output_dir=tempdir)
 
     def test_save_trajs_w_anchor_None(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags_and_top
         with _TDir(suffix='_test_mdciao') as tempdir:
             CG.save_trajs("test", None, verbose=True, t_unit="ns",
                           output_dir=tempdir)
 
     def test_save_trajs_w_anchor_basename(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags_and_top
         # Overwrite the trajlabels for the basename to work
         CG._trajlabels = ["../non/existing/dir/traj1.xtc",
                           "../non/existing/dir/traj2.xtc"]
@@ -1937,9 +1936,7 @@ class TestContactGroupSavetrajs(TestBaseClassContactGroup):
                           output_dir=tempdir)
 
     def test_save_trajs_w_anchor_cutoff(self):
-        CG = contacts.ContactGroup([self.cp1_w_anchor_and_frags_and_top,
-                                    self.cp2_w_anchor_and_frags_and_top],
-                                   )
+        CG = self.CG_cp1_cp2_both_w_anchor_and_frags_and_top
         with _TDir(suffix='_test_mdciao') as tempdir:
             CG.save_trajs("test_None", "dat", verbose=True, t_unit="ns",
                           ctc_cutoff_Ang=2.5,

--- a/tests/test_str_and_dict_utils.py
+++ b/tests/test_str_and_dict_utils.py
@@ -736,12 +736,12 @@ class Test_FilenameGenerator(unittest.TestCase):
     def test_just_runs(self):
 
         fn = str_and_dict.FilenameGenerator("beta2 Gs",3.5,"project","png")
-        self.assertEqual(fn.fname_overall, "project/beta2_Gs.overall@3.5_Ang.png")
-        self.assertEqual(fn.fname_excel,"project/beta2_Gs.overall@3.5_Ang.xlsx")
-        self.assertEqual(fn.fname_dat,"project/beta2_Gs.overall@3.5_Ang.dat")
-        self.assertEqual(fn.fname_pdb,"project/beta2_Gs.overall@3.5_Ang.as_bfactors.pdb")
-        self.assertEqual(fn.fname_mat,"project/beta2_Gs.matrix@3.5_Ang.png")
-        self.assertEqual(fn.fname_flare,"project/beta2_Gs.flare@3.5_Ang.pdf")
+        self.assertEqual(fn.fullpath_overall_fig, "project/beta2_Gs.overall@3.5_Ang.png")
+        self.assertEqual(fn.fullpath_overall_excel, "project/beta2_Gs.overall@3.5_Ang.xlsx")
+        self.assertEqual(fn.fullpath_overall_dat, "project/beta2_Gs.overall@3.5_Ang.dat")
+        self.assertEqual(fn.fullpath_pdb, "project/beta2_Gs.overall@3.5_Ang.as_bfactors.pdb")
+        self.assertEqual(fn.fullpath_matrix, "project/beta2_Gs.matrix@3.5_Ang.png")
+        self.assertEqual(fn.fullpath_flare_pdf, "project/beta2_Gs.flare@3.5_Ang.pdf")
 
 
 

--- a/tests/test_str_and_dict_utils.py
+++ b/tests/test_str_and_dict_utils.py
@@ -734,25 +734,9 @@ if __name__ == '__main__':
 class Test_FilenameGenerator(unittest.TestCase):
 
     def test_just_runs(self):
-        """
-        from collections import namedtuple as _ntup
-        graphic_ext = graphic_ext.strip(".")
-        fn = _ntup("project_filenames", ["fname_histo","fname_excel","fname_dat","fname_pdb","fname_mat","fname_flare"])
-        fname_wo_ext = "%s.overall@%2.1f_Ang" % (output_desc.replace(" ", "_"), ctc_cutoff_Ang)
-        fname_wo_ext = _path.join(output_dir, fname_wo_ext)
-        fname_histo = ".".join([fname_wo_ext, graphic_ext])
-        fname_excel = ".".join([fname_wo_ext, "xlsx"])
-        fname_dat = ".".join([fname_wo_ext, "dat"])
-        fname_pdb = ".".join([fname_wo_ext, "as_bfactors.pdb"])
-        fname_mat = fname_histo.replace("overall@", "matrix@")
-        fname_flare = '.'.join([fname_wo_ext.replace("overall@", "flare@"), 'pdf'])
 
-        Returns
-        -------
-
-        """
         fn = str_and_dict.FilenameGenerator("beta2 Gs",3.5,"project","png")
-        self.assertEqual(fn.fname_histo,"project/beta2_Gs.overall@3.5_Ang.png")
+        self.assertEqual(fn.fname_overall, "project/beta2_Gs.overall@3.5_Ang.png")
         self.assertEqual(fn.fname_excel,"project/beta2_Gs.overall@3.5_Ang.xlsx")
         self.assertEqual(fn.fname_dat,"project/beta2_Gs.overall@3.5_Ang.dat")
         self.assertEqual(fn.fname_pdb,"project/beta2_Gs.overall@3.5_Ang.as_bfactors.pdb")


### PR DESCRIPTION
ContactGroups get new attribute excluded_neighbors at instantiation, the user doesn't have to remember to pass it along to other methods. CGs with is_neighborhood True fail to instantiate if excluded_neighbors is not passed