### PR TITLE
Alignment DataFrame

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinx.ext.autosectionlabel",
+    "sphinx.ext.todo",
     "sphinxarg.ext",
     "sphinx.ext.intersphinx",
     'sphinx_copybutton',
@@ -139,6 +140,9 @@ def rename_thumbnails(*args):
         exp = f"_build/doctrees/nbsphinx/notebooks_{nb_basename}_*_*.png" #doctrees/nbsphinx seems to be created already after "html-page-context"
         cands = [ff for ff in natsorted(glob(exp)) if not ff.endswith("selected_thumbnail.png")]
         #logger.info(f"Picking nr {fig_idx} from available files:"+"\n"+"\n".join(cands))
+        if not cands:
+            logger.warning(f"No thumbnails found for {nb_basename}")
+            continue
         source_name = cands[fig_idx]
         target_name = f"_build/doctrees/nbsphinx/notebooks_{nb_basename}_selected_thumbnail.png"
         #logger.info(f"Will copy {source_name} to {target_name}")

--- a/mdciao/flare/_utils.py
+++ b/mdciao/flare/_utils.py
@@ -648,13 +648,13 @@ def change_axlims_and_resize_Texts(iax, new_r, center=[0, 0]):
     -------
 
     """
-    old_d_x = _np.abs(_np.diff(iax.get_xlim()))
-    old_d_y = _np.abs(_np.diff(iax.get_ylim()))
+    old_d_x = _np.abs(_np.diff(iax.get_xlim()))[0]
+    old_d_y = _np.abs(_np.diff(iax.get_ylim()))[0]
     assert iax.get_aspect()==1
     assert old_d_x==old_d_y
     iax.set_xlim([center[0] - new_r, center[0] + new_r])
     iax.set_ylim([center[1] - new_r, center[1] + new_r])
-    new_d = _np.abs(_np.diff(iax.get_xlim()))
+    new_d = _np.abs(_np.diff(iax.get_xlim()))[0]
     [lab.set_fontsize(lab.get_fontsize() * (old_d_x / new_d)) for lab in iax.texts]
 
 def cart2pol(x, y):

--- a/mdciao/flare/flare.py
+++ b/mdciao/flare/flare.py
@@ -417,7 +417,7 @@ def freqs2flare(freqs, res_idxs_pairs,
     if subplot:
         if ax is ax.figure.axes[-1]:
             [_futils.fontsize_apply(ax, jax) for jax in ax.figure.axes]
-            minwidth = min([_np.unique([line.get_linewidth() for line in jax.findobj(_Line2D)]) for jax in ax.figure.axes])
+            minwidth = min([_np.min([line.get_linewidth() for line in jax.findobj(_Line2D)]) for jax in ax.figure.axes])
             [[line.set_linewidth(minwidth) for line in jax.lines] for jax in ax.figure.axes]
     return ax, idxs_of_pairs2plot, plot_attribs
 

--- a/mdciao/fragments/fragments.py
+++ b/mdciao/fragments/fragments.py
@@ -1387,18 +1387,18 @@ def assign_fragments(res_idxs, fragments, raise_on_missing=True):
 
     Returns
     -------
-    frag_idxs : np.array
+    frag_idxs : np.ndarray
         Array with the indices of
-        :obj:`fragments` where each
-        residue of :obj:`res_isxs`
+        `fragments` where each
+        residue of `res_idxs`
         appears
-    res_idxs : np.array
+    res_idxs : np.ndarray
         If all residues were
-        found in :obj:`fragments`,
+        found in `fragments`,
         then this is a copy of the
         input array. If some didn't
         appear anywhere, but
-        :obj:`raise_on_missing` was
+        `raise_on_missing` was
         False, the missing residues
         have been deleted
     """
@@ -1406,7 +1406,8 @@ def assign_fragments(res_idxs, fragments, raise_on_missing=True):
     _mdcu.lists.assert_no_intersection(fragments, word="fragments")
     frag_idxs = _mdcu.lists.in_what_N_fragments(res_idxs, fragments)
     orphans = _np.flatnonzero([len(par) == 0 for par in frag_idxs])
-    frag_idxs = [[int(ii) if len(ii)>0 else ii][0] for ii in frag_idxs]
+    assert all([len(ii)<=1 for ii in frag_idxs]) #Should be True since we assert_no_intersection
+    frag_idxs = [(int(ii[0]) if len(ii)!=0 else ii) for ii in frag_idxs]
     if len(orphans)>0:
         if raise_on_missing:
             raise ValueError("residues %s don't appear in any 'fragments'. "

--- a/mdciao/nomenclature/nomenclature.py
+++ b/mdciao/nomenclature/nomenclature.py
@@ -745,8 +745,8 @@ class LabelerConsensus(object):
 
 
             idf = _mdcu.sequence.AlignmentDataFrame(idf.merge(_DataFrame(
-                {"idx_0": _np.arange(len(topidx2conlab)),
-                 "conlab": topidx2conlab}), how="left", on="idx_0"), #.replace(_np.nan, None)
+                {idf.colmap["idx_0"]: _np.arange(len(topidx2conlab)),
+                 "conlab": topidx2conlab}), how="left", on=idf.colmap["idx_0"]), #.replace(_np.nan, None)
                 alignment_score=idf.alignment_score)
             # .replace has ffil problem with pandas < 1.5, not with > 2. allowing
             idf.conlab = [[val if val is not _np.nan else None][0] for val in idf.conlab.values]
@@ -802,8 +802,8 @@ class LabelerConsensus(object):
 
                         if verbose:
                             _mdcu.sequence.print_verbose_dataframe(
-                                idf[idf[idf.idx_0.values == confragidxs[0]].index[0] - 1 - 5:
-                                    idf[idf.idx_0.values == confragidxs[-1]].index[0] + 2 +5]
+                                idf[idf[idf[idf.colmap["idx_0"]].values == confragidxs[0]].index[0] - 1 - 5:
+                                    idf[idf[idf.colmap["idx_0"]].values == confragidxs[-1]].index[0] + 2 +5]
                             )
 
 
@@ -2015,7 +2015,7 @@ def _alignment_df2_conslist(alignment_as_df,
         _df = alignment_as_df
     _df = _df[_df["match"]]
 
-    out_list[_df["idx_0"].values.astype(int)] = _df["conlab"].values
+    out_list[_df[_df.colmap["idx_0"]].values.astype(int)] = _df["conlab"].values
     return out_list.tolist()
 
 

--- a/mdciao/nomenclature/nomenclature.py
+++ b/mdciao/nomenclature/nomenclature.py
@@ -724,21 +724,21 @@ class LabelerConsensus(object):
             seq_1_res_idxs = self.dataframe[self.dataframe.chain_id == chain_id[0]].index
         else:
             seq_1_res_idxs = None
-        df = _mdcu.sequence.align_tops_or_seqs(top,
-                                               self.seq,
-                                               seq_0_res_idxs=restrict_to_residxs,
-                                               seq_1_res_idxs=seq_1_res_idxs,
-                                               return_DF=True,
-                                               verbose=verbose,
-                                               )
+        algs_as_dfs = _mdcu.sequence.align_tops_or_seqs(top,
+                                                        self.seq,
+                                                        seq_0_res_idxs=restrict_to_residxs,
+                                                        seq_1_res_idxs=seq_1_res_idxs,
+                                                        return_DF=True,
+                                                        verbose=verbose,
+                                                        )
         consfrags = []
         # For clever alternatives https://stackoverflow.com/a/3844832
-        for ii, idf in enumerate(df):
+        for ii, idf in enumerate(algs_as_dfs):
             top2self, self2top = _mdcu.sequence.df2maps(idf)
             consfrags.append(self._selfmap2frags(self2top))
-        n_alignments=len(df)
+        n_alignments=len(algs_as_dfs)
         frags_already_printed = False
-        for ii, idf in enumerate(df):
+        for ii, idf in enumerate(algs_as_dfs):
             top2self, self2top = _mdcu.sequence.df2maps(idf)
             topidx2conlab = _np.full([len(top) if isinstance(top,str) else top.n_residues][0], None)
             topidx2conlab[list(top2self.keys())] = self.dataframe.iloc[list(top2self.values())][self._conlab_column]
@@ -817,10 +817,10 @@ class LabelerConsensus(object):
                             current_clashing_residues = f"The following residues of your input `top` seem to be the problem: {only_in_top}. "
                             istr = current_clashing_confrag+current_clashing_residues
 
-                            if ii<len(df)-1:
+                            if ii<len(algs_as_dfs)-1:
                                     istr += f"Moving to the next equally scored alignment" \
                                             f" (score={idf.alignment_score:.2f}) to check if these clashes disappear."
-                            elif ii==len(df)-1:
+                            elif ii==len(algs_as_dfs)-1:
                                 istr += f"This was the last available alignment."
                             if not verbose:
                                 istr += f" Re-rerun 'mdciao.nomenclature.{type(self).__name__}.aligntop' with `verbose=True` to show the problematic part of this alignment here."

--- a/mdciao/plots/plots.py
+++ b/mdciao/plots/plots.py
@@ -983,7 +983,7 @@ def compare_groups_of_contacts(groups,
                                         fontsize=fontsize,
                                         **kwargs_plot_unified_freq_dicts)
                 if anchor is not None:
-                    _plt.gca().text(0 - _np.abs(_np.diff(_plt.gca().get_xlim())) * .05, 1.05,
+                    _plt.gca().text(0 - _np.abs(_np.diff(_plt.gca().get_xlim()))[0] * .05, 1.05,
                                     "%s and:" % _mdcu.str_and_dict.latex_superscript_fragments(anchor),
                                     ha="right", va="bottom")
 

--- a/mdciao/utils/sequence.py
+++ b/mdciao/utils/sequence.py
@@ -30,16 +30,16 @@ from Bio import Align as _BioAlign
 # See "Define original properties" https://pandas.pydata.org/pandas-docs/stable/development/extending.html#define-original-properties
 class _ADF(_DF):
     r"""
-    Sub-class of an :obj:`~pandas.DataFrame` to include the alignment_score as metadata.
+    Sub-class of an :obj:`~pandas.DataFrame` to include the alignment_score and the column key-map as metadata.
 
-    It can be then accessed via self.alignment_score and is preserved downstream
+    They can be then accessed via self.alignment_score, self.colmap and are preserved downstream
 
     Check https://pandas.pydata.org/pandas-docs/stable/development/extending.html#define-original-properties
     for more info
     """
 
     # normal properties
-    _metadata = ["alignment_score"]
+    _metadata = ["alignment_score", "colmap"]
 
     @property
     def _constructor(self):
@@ -48,11 +48,11 @@ class _ADF(_DF):
 
 class AlignmentDataFrame(_ADF):
     r"""
-    Sub-class of an :obj:`~pandas.DataFrame` to include the alignment_score as metadata.
+    Sub-class of an :obj:`~pandas.DataFrame` to include the alignment_score and the column key-map as metadata.
 
-    Simply pass it as argument ' alignment_score=1' and it:
-     * can be then accessed via self.alignment_score and
-     * it is preserved downstream after operating on the df
+    Simply pass them as arguments 'alignment_score=1, colmap={"idx_0" : "idx_Ecoli", ...} ' and they:
+     * can be then accessed via self.alignment_score and self.colmap
+     * are preserved downstream after operating on the df
 
     Check https://pandas.pydata.org/pandas-docs/stable/development/extending.html#define-original-properties
     for more info
@@ -62,8 +62,25 @@ class AlignmentDataFrame(_ADF):
         alignment_score = kwargs.get("alignment_score")
         if alignment_score is not None:
             kwargs.pop("alignment_score")
+
+        # This is the list that's the default in  :obj:`~mdciao.utils.sequence.alignment_result_to_list_of_dicts`
+        colmap_keys =  [
+            "AA_0",
+            "AA_1",
+            "resSeq_0",
+            "idx_0",
+            "idx_1",
+            'fullname_0',
+            'fullname_1',
+        ]
+        colmap = {key: key for key in colmap_keys}
+        for key, val in kwargs.pop("colmap",{}).items():
+            assert key in colmap.keys(), ValueError(f"Cannot pass a 'colmap' with a key '{key}' that isn't in '{colmap_keys}'")
+            colmap[key] = val
+
         super().__init__(*args,**kwargs)
         self.alignment_score = alignment_score
+        self.colmap = colmap
 
 def print_verbose_dataframe(df):
     r"""

--- a/mdciao/utils/sequence.py
+++ b/mdciao/utils/sequence.py
@@ -25,7 +25,7 @@ import pandas as _pd
 from IPython.display import display as _display
 from collections import namedtuple as _namedtuple
 from Bio import Align as _BioAlign
-
+from inspect import signature as _signature
 
 # See "Define original properties" https://pandas.pydata.org/pandas-docs/stable/development/extending.html#define-original-properties
 class _ADF(_DF):
@@ -81,6 +81,26 @@ class AlignmentDataFrame(_ADF):
         super().__init__(*args,**kwargs)
         self.alignment_score = alignment_score
         self.colmap = colmap
+
+def _get_colmap_keys():
+    r"""
+    Grab default values in :obj:`~mdciao.utils.sequence.alignment_result_to_list_of_dicts`
+
+    Returns
+    -------
+    colmap_keys : list
+
+    """
+    sig = _signature(alignment_result_to_list_of_dicts)
+    _colmap_keys = [sig.parameters.get(key).default for key in ["key_AA_code_seq_0",
+                                                                "key_resSeq_seq_0",
+                                                                "key_idx_seq_0",
+                                                                "key_full_resname_seq_0",
+                                                                "key_idx_seq_1",
+                                                                "key_AA_code_seq_1",
+                                                                "key_full_resname_seq_1"
+                                                                ]]
+    return _colmap_keys
 
 def print_verbose_dataframe(df):
     r"""

--- a/mdciao/utils/sequence.py
+++ b/mdciao/utils/sequence.py
@@ -503,8 +503,8 @@ def df2maps(df, allow_nonmatch=True):
     else:
         _df = df
 
-    top0_to_top1 = {key: val for key, val in zip(_df[_df["match"] == True]["idx_0"].to_list(),
-                                                 _df[_df["match"] == True]["idx_1"].to_list())}
+    top0_to_top1 = {key: val for key, val in zip(_df[_df["match"] == True][_df.colmap["idx_0"]].to_list(),
+                                                 _df[_df["match"] == True][_df.colmap["idx_1"]].to_list())}
 
     top1_to_top0 = {val:key for key, val in top0_to_top1.items()}
 
@@ -551,8 +551,8 @@ def re_match_df(df):
         for rr in match_ranges[False]:
             try:
                 if all(_df.loc[[rr[0] - 1, rr[-1] + 1]]["match"]) and \
-                        all(["-" not in df[key].values[rr] for key in ["AA_0",
-                                                                   "AA_1"]]):  # this checks for no insertions in the alignment ("=equal length ranges")
+                        all(["-" not in df[df.colmap[key]].values[rr] for key in ["AA_0",
+                                                                                  "AA_1"]]):  # this checks for no insertions in the alignment ("=equal length ranges")
                     _df.loc[rr, "match"] = True
             except KeyError:
                 continue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,39 +138,33 @@ class Test_residue_neighborhood(TestCLTBaseClass):
         super(Test_residue_neighborhood, cls).setUpClass()
         cls.no_disk = True  # doesn't seem to speed things up much
 
-    @mock.patch('builtins.input', lambda *args: '4')
-    def test_neighborhoods_no_disk_works(self):
+    @mock.patch('builtins.input', side_effects=1)
+    def test_neighborhoods_no_disk_works(self, mock_input):
         with TemporaryDirectory(suffix='_test_mdciao') as tmpdir:
             with remember_cwd():
                 os.chdir(tmpdir)
-                input_values = (val for val in ["1.0"])
-                with mock.patch('builtins.input', lambda *x: next(input_values)):
-                    cli.residue_neighborhoods("200,395",
-                                              self.traj,
-                                              self.geom,
-                                              no_disk=True
-                                              )
+                cli.residue_neighborhoods("200,395",
+                                          self.traj,
+                                          self.geom,
+                                          no_disk=True
+                                          )
                 assert len(os.listdir(".")) == 0
 
-    @mock.patch('builtins.input', lambda *args: '4')
-    def test_neighborhoods(self):
+    @mock.patch('builtins.input', side_effects=1)
+    def test_neighborhoods(self, mock_input):
         with TemporaryDirectory(suffix='_test_mdciao') as tmpdir:
-            input_values = (val for val in ["1.0"])
-            with mock.patch('builtins.input', lambda *x: next(input_values)):
-                cli.residue_neighborhoods("200,395",
-                                          [self.traj, self.traj_reverse],
-                                          self.geom,
-                                          output_dir=tmpdir,
-                                          no_disk=self.no_disk)
-
-    def test_no_top(self):
+            cli.residue_neighborhoods("200,395",
+                                      [self.traj, self.traj_reverse],
+                                      self.geom,
+                                      output_dir=tmpdir,
+                                      no_disk=self.no_disk)
+    @mock.patch('builtins.input', side_effects=1)
+    def test_no_top(self, mock_input):
         with TemporaryDirectory(suffix='_test_mdciao') as tmpdir:
-            input_values = (val for val in ["1.0"])
-            with mock.patch('builtins.input', lambda *x: next(input_values)):
-                cli.residue_neighborhoods("200,395",
-                                          self.geom,
-                                          output_dir=tmpdir,
-                                          no_disk=self.no_disk)
+            cli.residue_neighborhoods("200,395",
+                                      self.geom,
+                                      output_dir=tmpdir,
+                                      no_disk=self.no_disk)
 
     def test_res_idxs(self):
         with TemporaryDirectory(suffix='_test_mdciao') as tmpdir:

--- a/tests/test_nomenclature.py
+++ b/tests/test_nomenclature.py
@@ -18,7 +18,7 @@ from mdciao.nomenclature import nomenclature
 from mdciao.examples import filenames as test_filenames
 from mdciao.utils.lists import assert_no_intersection
 from mdciao import examples
-from mdciao.utils.sequence import top2seq
+from mdciao.utils.sequence import top2seq, AlignmentDataFrame
 from mdciao.utils.residue_and_atom import shorten_AA
 from mdciao.fragments import get_fragments, fragment_slice
 
@@ -1064,7 +1064,7 @@ class Test_alignment_df2_conslist(unittest.TestCase):
              "conlab": "3.52",
              },
         ]
-        cls.df = DataFrame(cls.list_of_dicts)
+        cls.df = AlignmentDataFrame(cls.list_of_dicts)
         # cls.consensus_dict = {"GLU0": "3.50",
         #                      "ARG1": "3.51",
         #                      "PHE2": "3.52"}

--- a/tests/test_residue_and_atom_utils.py
+++ b/tests/test_residue_and_atom_utils.py
@@ -358,14 +358,12 @@ class Test_residues_from_descriptors(unittest.TestCase):
                                                    additional_resnaming_dicts=consensus_dicts,
                                                    pick_this_fragment_by_default=0
                                                    )
-
-    def test_answer_letters(self):
+    @mock.patch('builtins.input', side_effects=["0.0", "4.0"])
+    def test_answer_letters(self, mock_input):
         residues = ["GLU30", "TRP32"]
-        input_values = (val for val in ["0.0", "4.0"])
-        with mock.patch('builtins.input', lambda *x: next(input_values)):
-            residue_and_atom.residues_from_descriptors(residues, self.by_bonds_geom2frags,
-                                                       self.geom2frags.top,
-                                                       )
+        residue_and_atom.residues_from_descriptors(residues, self.by_bonds_geom2frags,
+                                                   self.geom2frags.top,
+                                                   )
 
 
 class Test_rangeexpand_residues2residxs(unittest.TestCase):

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -233,6 +233,21 @@ class Test_AlignmentDataframe(unittest.TestCase):
         df = sequence.AlignmentDataFrame({"A": [1, 2, 3], "B": [4, 5, 6], "C": [7, 8, 9]},alignment_score=1)
         assert df.alignment_score == 1
         assert df[["A", "B"]].alignment_score == 1
+        self.assertDictEqual(df.colmap, {key: key for key in ["AA_0",
+                                                              "AA_1",
+                                                              "resSeq_0",
+                                                              "idx_0",
+                                                              "idx_1",
+                                                              'fullname_0',
+                                                              'fullname_1']})
+
+    def test_just_colmap_is_there(self):
+        #     Check https://pandas.pydata.org/pandas-docs/stable/development/extending.html#define-original-properties
+        # for more info
+        df = sequence.AlignmentDataFrame({"A": [1, 2, 3], "B": [4, 5, 6], "C": [7, 8, 9]},alignment_score=1, colmap={"idx_0" : "idx_Ecoli"})
+        assert df.alignment_score == 1
+        assert df[["A", "B"]].alignment_score == 1
+        assert df.colmap["idx_0"]=="idx_Ecoli"
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -38,6 +38,32 @@ class Test_align_tops(unittest.TestCase):
         assert df.alignment_score == top.n_residues
         #sequence.print_verbose_dataframe(df)
 
+    def test_works_w_itself_colmap_dict(self):
+        top = md.load(test_filenames.small_monomer).top
+        df = sequence.align_tops_or_seqs(top, top, ADF_colmap={"idx_0": "idx_WT", "idx_1": "idx_MUT"})[0]
+        assert isinstance(df, _DF)
+        assert isinstance(df, sequence.AlignmentDataFrame)
+        assert df.alignment_score == top.n_residues
+        assert "idx_WT" in df.columns
+        assert "idx_MUT" in df.columns
+        assert "idx_0" not in df.columns
+        assert "idx_1" not in df.columns
+        #sequence.print_verbose_dataframe(df)
+
+    def test_works_w_itself_colmap_list(self):
+        top = md.load(test_filenames.small_monomer).top
+        df = sequence.align_tops_or_seqs(top, top, ADF_colmap=["WT", "MUT"])[0]
+        assert isinstance(df, _DF)
+        assert isinstance(df, sequence.AlignmentDataFrame)
+        assert df.alignment_score == top.n_residues
+        assert "idx_WT" in df.columns
+        assert "idx_MUT" in df.columns
+        assert "idx_0" not in df.columns
+        assert "idx_1" not in df.columns
+        #sequence.print_verbose_dataframe(df)
+        assert set(df.columns) == set(['AA_WT', 'resSeq_WT', 'idx_WT', 'fullname_WT',
+                                       'idx_MUT', 'AA_MUT', 'fullname_MUT']+["match"])
+
     def test_works_w_itself_list(self):
         top = md.load(test_filenames.small_monomer).top
         df = sequence.align_tops_or_seqs(top, top, return_DF=False)[0]


### PR DESCRIPTION
When pairwise alignments were returned as DataFrames, column names like "index", "resname" etc were suffixed as _0 or _1 depending on what sequence they belonged to....which was not particularly informative and forced the user to remember, every time, which was seq0 and seq1.

Now, while this behavior is kept as default, users can pass more informative descriptors, either explicitly as maps (dicts) or implicitly as a pair of suffixes, to utils.sequence.align_tops_or_seqs, via the new argument ADF_colmap.

At the lower level, mdciao's Alignment DataFrame, which subclasses pandas DataFrame, carries the metadata about the map s.t. internally, columns can be accessed via adf[adf.colmap["idx_0"]] regardless of the map

